### PR TITLE
Inner-Product Verification with Multiexponentiation | Inner-Product Protocol for Non-powers of 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Cargo.lock
 **/*.rs.bk
 
 .idea
+/ipp_explanation/

--- a/src/proofs/inner_product.rs
+++ b/src/proofs/inner_product.rs
@@ -257,6 +257,7 @@ impl InnerProductArg {
         assert!(n.is_power_of_two());
 
         let lg_n = self.L.len();
+        assert!(lg_n < 64, "Not compatible for vector sizes greater than 2^64!");
 
         let mut x_sq_vec: Vec<BigInt> = Vec::with_capacity(lg_n);
         let mut x_inv_sq_vec: Vec<BigInt> = Vec::with_capacity(lg_n);
@@ -283,7 +284,7 @@ impl InnerProductArg {
         let mut s: Vec<BigInt> = Vec::with_capacity(n);
         s.push(allinv);
         for i in 1..n {
-            let lg_i = (32 - 1 - (i as u32).leading_zeros()) as usize;
+            let lg_i = (64 - 1 - ((i as u64).leading_zeros() as usize)) as usize;
             let k = 1 << lg_i;
             // The challenges are stored in "creation order" as [x_k,...,x_1],
             // so u_{lg(i)+1} = is indexed by (lg_n-1) - lg_i

--- a/src/proofs/inner_product.rs
+++ b/src/proofs/inner_product.rs
@@ -257,7 +257,7 @@ impl InnerProductArg {
         assert!(n.is_power_of_two());
 
         let lg_n = self.L.len();
-        assert!(lg_n < 64, "Not compatible for vector sizes greater than 2^64!");
+        assert!(lg_n <= 64, "Not compatible for vector sizes greater than 2^64!");
 
         let mut x_sq_vec: Vec<BigInt> = Vec::with_capacity(lg_n);
         let mut x_inv_sq_vec: Vec<BigInt> = Vec::with_capacity(lg_n);

--- a/src/proofs/inner_product.rs
+++ b/src/proofs/inner_product.rs
@@ -284,7 +284,7 @@ impl InnerProductArg {
         let mut s: Vec<BigInt> = Vec::with_capacity(n);
         s.push(allinv);
         for i in 1..n {
-            let lg_i = (64 - 1 - ((i as u64).leading_zeros() as usize)) as usize;
+            let lg_i = (std::mem::size_of_val(&n) * 8) - 1 - ((i as usize).leading_zeros() as usize);
             let k = 1 << lg_i;
             // The challenges are stored in "creation order" as [x_k,...,x_1],
             // so u_{lg(i)+1} = is indexed by (lg_n-1) - lg_i

--- a/src/proofs/inner_product.rs
+++ b/src/proofs/inner_product.rs
@@ -272,9 +272,7 @@ impl InnerProductArg {
             let x_sq_bn = BigInt::mod_mul(&x_bn, &x_bn, &order);
             let x_inv_sq_bn =
                 BigInt::mod_mul(&x_inv_fe.to_big_int(), &x_inv_fe.to_big_int(), &order);
-            // let x_sq_fe: FE = ECScalar::from(&x_sq_bn);
-            // let x_inv_sq_fe: FE = ECScalar::from(&x_inv_sq_bn);
-
+            
             x_sq_vec.push(x_sq_bn.clone());
             x_inv_sq_vec.push(x_inv_sq_bn.clone());
             minus_x_sq_vec.push(BigInt::mod_sub(&BigInt::zero(), &x_sq_bn, &order));
@@ -539,19 +537,6 @@ mod tests {
         let hash = HSha512::create_hash(&[&label]);
         let Gx = generate_random_point(&Converter::to_vec(&hash));
 
-        // let a: Vec<_> = (0..n)
-        //     .map(|_| {
-        //         let rand: FE = ECScalar::new_random();
-        //         rand.to_big_int()
-        //     })
-        //     .collect();
-
-        // let b: Vec<_> = (0..n)
-        //     .map(|_| {
-        //         let rand: FE = ECScalar::new_random();
-        //         rand.to_big_int()
-        //     })
-        //     .collect();
         let c = super::inner_product(&a, &b);
         
         let y: FE = ECScalar::new_random();
@@ -573,18 +558,6 @@ mod tests {
         let c_fe: FE = ECScalar::from(&c);
 
         let ux_c: GE = &Gx * &c_fe;
-        // let a_G = g_vec.iter().zip(a.clone()).fold(ux_c, |acc, x| {
-        //     if x.1 != BigInt::zero() {
-        //         // Mult and Add only if the element cL[i] is not zero
-        //         let cL_i_fe: FE = ECScalar::from(&x.1);
-        //         let cL_i_fe_g_i: GE = x.0 * &cL_i_fe;
-        //         acc.add_point(&cL_i_fe_g_i.get_element())
-        //     } else {
-        //         // move on otherwise
-        //         acc
-        //     }
-        // });
-
         
         let a_G = (0..m)
             .map(|i| {


### PR DESCRIPTION
1. Faster inner product proof verification using a single multi-exponentiation as described in Section 3.1 of the [Bulletproofs](https://eprint.iacr.org/2017/1066.pdf) paper. Improves the inner product verification by **~30%** 

2. Protocols similar in spirit to Bulletproofs require support for inner product protocol with secret vector sizes a non-power of 2. I have added a test demonstrating the same. The idea is simple: 
2.1 Append secret vectors with 0's to make them the next power of 2
2.2 Extend the original base vectors to make them too the next power of 2
2.3 Compute vector exponentiations with a condition to check any 0's. This ensures minimum overhead computational cost due to modification of vector sizes to the next power of 2.
   